### PR TITLE
Fix not detecting timeouts when clocks are out of sync.

### DIFF
--- a/lib/helpers/handle_data.helper.dart
+++ b/lib/helpers/handle_data.helper.dart
@@ -104,7 +104,10 @@ class HandleDataHelper with CallbacksStore {
 
   void _onConfirmSubscription(Map payload) {
     final channelId = IdentifierHelper.parseChannelId(payload['identifier']);
+
+    // Remove the subscribeTimedOut callback after the subscription was confirmed.
     final onSubscribed = CallbacksStore.subscribed[channelId];
+    CallbacksStore.subscribeTimedOut.remove(channelId);
     if (onSubscribed != null) {
       onSubscribed();
     }

--- a/lib/helpers/handle_data.helper.dart
+++ b/lib/helpers/handle_data.helper.dart
@@ -87,12 +87,11 @@ class HandleDataHelper with CallbacksStore {
     actionCallback.callback(response);
   }
 
-  void _onPing(Map payload) {
-    // rails sends epoch as seconds not miliseconds
-    final lastPing = DateTime.fromMillisecondsSinceEpoch(
-      payload['message'] * 1000,
-    );
-    _onPingMessage(lastPing);
+  void _onPing(Map _) {
+    // Note: You cannot rely on the clocks being synchronized. Therefore, you cannot use the
+    // timestamp of the server to detect timeouts! ALWAYS use your local clock!!!
+    // It could also be wrong, but that's not a problem as long as we compare the times with ourselves!
+    _onPingMessage(DateTime.now());
   }
 
   void _onWelcome() => _onConnected?.call();

--- a/lib/models/action_cable.dart
+++ b/lib/models/action_cable.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:web_socket_channel/web_socket_channel.dart';
-import 'package:x_action_cable/store/callbacks.store.dart';
+import 'package:x_action_cable/store/action_channel_callbacks_store.dart';
 import 'package:x_action_cable/types.dart';
 import 'package:x_action_cable/web_socket/abstractions/web_socket.interface.dart';
 
@@ -30,6 +30,9 @@ class ActionCable {
   /// Timer for helth check
   late Timer _timer;
 
+  final ActionChannelCallbacksStore _actionChannelCallbacksStore =
+      ActionChannelCallbacksStore();
+
   /// Factory for connect to ActionCable on Rails
   ActionCable.connect(
     String url, {
@@ -39,6 +42,7 @@ class ActionCable {
     required void Function(dynamic reason)? onCannotConnect,
   }) {
     final handleDataHelper = _createHandleDataHelper(
+      actionChannelCallbacksStore: this._actionChannelCallbacksStore,
       onConnected: onConnected,
       onConnectionLost: onConnectionLost,
     );
@@ -52,10 +56,12 @@ class ActionCable {
   }
 
   HandleDataHelper _createHandleDataHelper({
+    required ActionChannelCallbacksStore actionChannelCallbacksStore,
     required VoidCallback? onConnected,
     required VoidCallback? onConnectionLost,
   }) {
     return HandleDataHelper(
+      actionChannelCallbacksStore: actionChannelCallbacksStore,
       onConnected: onConnected,
       onPingMessage: (time) {
         _lastPing = time;
@@ -97,6 +103,12 @@ class ActionCable {
     _timer.cancel();
     _socketChannel.sink.close();
     _listener.cancel();
+
+    // All action channels are disconnected when the main ActionCable connection is.
+    for (VoidCallback? onDisconnected
+        in this._actionChannelCallbacksStore.disconnected.values) {
+      onDisconnected?.call();
+    }
   }
 
   void _send(Map<String, dynamic> payload) {
@@ -147,14 +159,16 @@ class ActionCable {
       channelParams,
     );
 
-    CallbacksStore.subscribed[identifier] = onSubscribed;
-    CallbacksStore.subscribeTimedOut[identifier] = onSubscribeTimedOut;
-    CallbacksStore.diconnected[identifier] = onDisconnected;
-    CallbacksStore.message[identifier] = callbacks;
+    this._actionChannelCallbacksStore.subscribed[identifier] = onSubscribed;
+    this._actionChannelCallbacksStore.subscribeTimedOut[identifier] =
+        onSubscribeTimedOut;
+    this._actionChannelCallbacksStore.disconnected[identifier] = onDisconnected;
+    this._actionChannelCallbacksStore.message[identifier] = callbacks;
 
     _send({'identifier': identifier, 'command': 'subscribe'});
 
     return ActionChannel(
+      actionChannelCallbacksStore: this._actionChannelCallbacksStore,
       identifier: identifier,
       subscriptionTimeout: subscriptionTimeout,
       sendMessageCallback: _send,

--- a/lib/models/action_channel.dart
+++ b/lib/models/action_channel.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:x_action_cable/store/callbacks.store.dart';
+import 'package:x_action_cable/store/action_channel_callbacks_store.dart';
 import 'package:x_action_cable/types.dart';
 
 /// This class represents the channel that you are going to perfome actions
@@ -13,6 +13,8 @@ import 'package:x_action_cable/types.dart';
 /// );
 /// ```
 class ActionChannel {
+  final ActionChannelCallbacksStore actionChannelCallbacksStore;
+
   final String identifier;
 
   final Duration subscriptionTimeout;
@@ -21,6 +23,7 @@ class ActionChannel {
   Timer? _subscriptionTimeoutTimer;
 
   ActionChannel({
+    required this.actionChannelCallbacksStore,
     required this.identifier,
     required this.subscriptionTimeout,
     required SendMessageCallback sendMessageCallback,
@@ -33,7 +36,7 @@ class ActionChannel {
         // callback will have been removed by now.
         // Otherwise this is a timeout.
         final VoidCallback? subscriptionTimeout =
-            CallbacksStore.subscribeTimedOut[this.identifier];
+            this.actionChannelCallbacksStore.subscribeTimedOut[this.identifier];
         subscriptionTimeout?.call();
       },
     );
@@ -44,10 +47,10 @@ class ActionChannel {
   /// channel.unsubscribe();
   /// ```
   void unsubscribe() {
-    CallbacksStore.subscribed.remove(identifier);
-    CallbacksStore.subscribeTimedOut.remove(identifier);
-    CallbacksStore.diconnected.remove(identifier);
-    CallbacksStore.message.remove(identifier);
+    this.actionChannelCallbacksStore.subscribed.remove(identifier);
+    this.actionChannelCallbacksStore.subscribeTimedOut.remove(identifier);
+    this.actionChannelCallbacksStore.disconnected.remove(identifier);
+    this.actionChannelCallbacksStore.message.remove(identifier);
 
     this._subscriptionTimeoutTimer?.cancel();
 

--- a/lib/store/action_channel_callbacks_store.dart
+++ b/lib/store/action_channel_callbacks_store.dart
@@ -1,0 +1,9 @@
+import 'package:x_action_cable/types.dart';
+
+/// Callback stores for action channels.
+class ActionChannelCallbacksStore {
+  Map<String, VoidCallback?> subscribed = {};
+  Map<String, VoidCallback?> disconnected = {};
+  Map<String, VoidCallback?> subscribeTimedOut = {};
+  OnMessageCallbacks message = {};
+}

--- a/lib/store/callbacks.store.dart
+++ b/lib/store/callbacks.store.dart
@@ -1,8 +1,0 @@
-import 'package:x_action_cable/types.dart';
-
-mixin CallbacksStore {
-  static Map<String, VoidCallback?> subscribed = {};
-  static Map<String, VoidCallback?> diconnected = {};
-  static Map<String, VoidCallback?> subscribeTimedOut = {};
-  static OnMessageCallbacks message = {};
-}

--- a/lib/store/callbacks.store.dart
+++ b/lib/store/callbacks.store.dart
@@ -3,5 +3,6 @@ import 'package:x_action_cable/types.dart';
 mixin CallbacksStore {
   static Map<String, VoidCallback?> subscribed = {};
   static Map<String, VoidCallback?> diconnected = {};
+  static Map<String, VoidCallback?> subscribeTimedOut = {};
   static OnMessageCallbacks message = {};
 }


### PR DESCRIPTION
This pull request fixes multiple issues:

# Timestamp Handling
Note: Clocks on mobile devices are usually out of sync. Thus we cannot use the timestamp sent by the server and compare it with our local clock. This will fail for sure!

I've checked the Javascript implementation from Rails. It is using the current time to compare whether a timeout occurs and ignores the timestamp that was sent by the server. 
This fix is doing the same

# Timeout Handler for action channels
New optional callback that is called when subscribing on a channel takes too long.

# Handle disconnect on the cable
Calling disconnect callback on channels when the action cable itself is disconnected